### PR TITLE
Use arrow function for class methods

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -71,24 +71,24 @@ export default class Editor extends Component {
     }
   }
 
-  onChange(newValue) {
+  onChange = newValue => {
     console.log('change', newValue);
     this.setState({
       value: newValue,
     });
   }
 
-  onSelectionChange(newValue, event) {
+  onSelectionChange = (newValue, event) => {
     console.log('select-change', newValue);
     console.log('select-change-event', event);
   }
 
-  onCursorChange(newValue, event) {
+  onCursorChange = (newValue, event) => {
     console.log('cursor-change', newValue);
     console.log('cursor-change-event', event);
   }
 
-  onValidate(annotations) {
+  onValidate = annotations => {
     console.log('onValidate', annotations);
   }
 


### PR DESCRIPTION
Use arrow function for class methods to avoid having to bind function